### PR TITLE
SystemAPI Fix Bug

### DIFF
--- a/Transform2D/Authoring/Transform2DConversionSystem.cs
+++ b/Transform2D/Authoring/Transform2DConversionSystem.cs
@@ -59,9 +59,8 @@ namespace NSprites
 
             if (parentEntity != Entity.Null) {
                 ecb.AddComponent(entity, new Parent2D {Value = parentEntity});
-                _ = EntityManager.HasComponent<Child2D>(parentEntity)
-                    ? SystemAPI.GetBuffer<Child2D>(parentEntity)
-                    : ecb.AddBuffer<Child2D>(parentEntity);
+                if(!EntityManager.HasComponent<Child2D>(parentEntity))
+                    ecb.AddBuffer<Child2D>(parentEntity);
             }
 
             for (int i = 0; i < transform.childCount; i++) {


### PR DESCRIPTION
We don't use SystemAPI in other func SysteamAPI uses Code Gen and Unity don't do this. I changed Tranform2DConversionSystem but i dont know SystemAPI.GetBuffer was important. Other changes is okey in my opinion.